### PR TITLE
Replaced deprecated JEI API functions

### DIFF
--- a/src/main/java/org/cyclops/integratedterminalscompat/modcompat/jei/terminalstorage/TerminalStorageGuiHandler.java
+++ b/src/main/java/org/cyclops/integratedterminalscompat/modcompat/jei/terminalstorage/TerminalStorageGuiHandler.java
@@ -1,39 +1,56 @@
 package org.cyclops.integratedterminalscompat.modcompat.jei.terminalstorage;
 
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
-import org.cyclops.integratedterminals.api.terminalstorage.ITerminalStorageTabClient;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.runtime.IClickableIngredient;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.common.input.ClickableIngredient;
+import mezz.jei.common.util.ImmutableRect2i;
 import org.cyclops.integratedterminals.client.gui.container.ContainerScreenTerminalStorage;
 import org.cyclops.integratedterminals.core.terminalstorage.TerminalStorageTabIngredientComponentClient;
 import org.cyclops.integratedterminalscompat.modcompat.jei.JEIIntegratedTerminalsConfig;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
  * This handler allows JEI to recognise the terminal storage slot contents.
  * @author rubensworks
+ * @author Snonky
  */
 public class TerminalStorageGuiHandler implements IGuiContainerHandler<ContainerScreenTerminalStorage<?, ?>> {
-    @Nullable
+
     @Override
-    public Object getIngredientUnderMouse(ContainerScreenTerminalStorage<?, ?> guiContainer, double mouseX, double mouseY) {
-        int slotIndex = guiContainer.getStorageSlotIndexAtPosition(mouseX, mouseY);
-        if (slotIndex >= 0) {
-            Optional<ITerminalStorageTabClient<?>> tabOptional = guiContainer.getSelectedClientTab();
-            if (tabOptional.isPresent()) {
-                ITerminalStorageTabClient<?> tab = tabOptional.get();
-                if (tab instanceof TerminalStorageTabIngredientComponentClient) {
-                    Object instance = ((TerminalStorageTabIngredientComponentClient) tab).getSlotInstance(
-                            guiContainer.getMenu().getSelectedChannel(), slotIndex).orElse(null);
-                    try {
-                        JEIIntegratedTerminalsConfig.jeiRuntime.getIngredientManager().getIngredientType(instance);
-                        return instance;
-                    } catch (IllegalArgumentException | NullPointerException e) {
-                        // Ignore ingredient types unsupported by JEI
-                    }
-                }
+    public @NotNull Optional<IClickableIngredient<?>> getClickableIngredientUnderMouse(
+            @NotNull ContainerScreenTerminalStorage<?, ?> containerScreen, double mouseX, double mouseY) {
+        Optional<? extends IClickableIngredient<?>> clickableIngredientOptional =
+                createClickableIngredient(containerScreen, mouseX,  mouseY);
+        return clickableIngredientOptional.map((clickableIngredient) -> (IClickableIngredient<?>) clickableIngredient);
+    }
+
+    private <T> Optional<IClickableIngredient<T>> createClickableIngredient(
+            ContainerScreenTerminalStorage<T, ?> containerScreen, double mouseX, double mouseY) {
+        int slotIndex = containerScreen.getStorageSlotIndexAtPosition(mouseX, mouseY);
+        @SuppressWarnings("unchecked") // Cast is safe due to filter
+        Optional<TerminalStorageTabIngredientComponentClient<T, ?>> tabOptional = containerScreen.getSelectedClientTab()
+                .filter(TerminalStorageTabIngredientComponentClient.class::isInstance)
+                .map(TerminalStorageTabIngredientComponentClient.class::cast);
+        if(slotIndex >= 0 && tabOptional.isPresent()) {
+            TerminalStorageTabIngredientComponentClient<T, ?> tab = tabOptional.get();
+            int channel = containerScreen.getMenu().getSelectedChannel();
+            IIngredientManager ingredientManager = JEIIntegratedTerminalsConfig.jeiRuntime.getIngredientManager();
+            Optional<T> instanceOptional = tab.getSlotInstance(channel, slotIndex);
+            Optional<IIngredientType<T>> ingredientTypeOptional = instanceOptional
+                    .flatMap(ingredientManager::getIngredientTypeChecked);
+            if (instanceOptional.isPresent() && ingredientTypeOptional.isPresent()) {
+                ImmutableRect2i slotRect = new ImmutableRect2i(containerScreen.getStorageSlotRect(slotIndex));
+                Optional<ITypedIngredient<T>> typedIngredientOptional = ingredientManager
+                        .createTypedIngredient(ingredientTypeOptional.get(), instanceOptional.get());
+                return typedIngredientOptional
+                        .map((typedIngredient) -> new ClickableIngredient<>(typedIngredient, slotRect));
             }
         }
-        return null;
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
### Resolving #7 
#### In case of a merge, this PR should be merged together with CyclopsMC/IntegratedTerminals#101

The following deprecations have been adressed:


* [`IGuiContainerHandler#getIngredientUnderMouse`](https://github.com/mezz/JustEnoughItems/blob/c83958436399abdc3581b16d0d73df56ea555073/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java#L47) &#8594; [`IGuiContainerHandler#getClickableIngredientUnderMouse`](https://github.com/mezz/JustEnoughItems/blob/c83958436399abdc3581b16d0d73df56ea555073/CommonApi/src/main/java/mezz/jei/api/gui/handlers/IGuiContainerHandler.java#L67)
     * Now returns a [`IClickableIngredient`](https://github.com/mezz/JustEnoughItems/blob/76278d489072fc1d3e3477df163228ae03e6e42e/CommonApi/src/main/java/mezz/jei/api/runtime/IClickableIngredient.java) instead of just the ingredient type instance
     * `IClickableIngredient` needs a `Rect2i` representing the ingredient slot's area
     * To get that area CyclopsMC/IntegratedTerminals#101 is needed
* [`IIngredientManager#getIngredientType`](https://github.com/mezz/JustEnoughItems/blob/6476d975359e1c2ff517d94b58ff2dcc7bf780ae/CommonApi/src/main/java/mezz/jei/api/runtime/IIngredientManager.java#L101) &#8594; [`IIngredientManager#getIngredientTypeChecked`](https://github.com/mezz/JustEnoughItems/blob/6476d975359e1c2ff517d94b58ff2dcc7bf780ae/CommonApi/src/main/java/mezz/jei/api/runtime/IIngredientManager.java#L86)
    * Now checks if the IngredientType is registered with JEI

